### PR TITLE
allow access to GetSoftenedColor for library users

### DIFF
--- a/WinFormsThemes/WinFormsThemes/Themes/AbstractTheme.cs
+++ b/WinFormsThemes/WinFormsThemes/Themes/AbstractTheme.cs
@@ -280,8 +280,12 @@ namespace WinFormsThemes.Themes
         /// <remarks>
         /// This should primarily thought of as helper function to use the same colors and modify them
         /// dependent on dark/light theme.
+        /// Although this could be done as a static method, I find it more easily understandable for a user to have
+        /// it as an instance method
         /// </remarks>
-        protected static Color GetSoftenedColor(Color baseColor, bool switchDarkAndLight = false)
+#pragma warning disable CA1822 // Member als statisch markieren
+        public Color GetSoftenedColor(Color baseColor, bool switchDarkAndLight = false)
+#pragma warning restore CA1822 // Member als statisch markieren
         {
             // HSL lightness value 0 = black, 1 = white
             if (baseColor.GetBrightness() < 0.5 || switchDarkAndLight)


### PR DESCRIPTION
## About this PR
When writing a theme plugin, we may want to use a slightly different color while still adhering to the general style (e.g. coloring the lines in a table). Before this PR, `AbstractTheme.GetSoftenedColor` was only available internally and for custom theme implementations. By making it public, plugin writers can now use it to color the table in the `theme.TableCellBackColor` and alternating rows in `theme.GetSoftenedColor(theme.TableCellBackColor)`

## ToDos
- [ ] We should discuss if we want to keep the method in `AbstractTheme` or not.

## Checklist

- [ ] ~~I have added a suitable test~~
- [ ] ~~I have updated the documentation in the readme~~
